### PR TITLE
Allow location to be a lat,lon coordiante pair

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,15 @@ var location = {
   type: 'name',
   name: process.env.PGO_LOCATION,
 };
+var geo = process.env.PGO_LOCATION.match(/^(-?\d+\.\d+),(-?\d+\.\d+)$/);
+if ( geo ){
+  location.type = 'coords';
+  location.coords = {
+    latitude:parseFloat(geo[1]),
+    longitude:parseFloat(geo[2]),
+    altitude:0.0
+  }
+}
 
 var username = process.env.PGO_USERNAME;
 var password = process.env.PGO_PASSWORD;

--- a/logger.js
+++ b/logger.js
@@ -4,7 +4,7 @@ var logger;
 if ( process.env.LOGGLY_TOKEN ){
   logger = require('winston');
   require('winston-loggly-bulk');
-  logger.add(winston.transports.Loggly, {
+  logger.add(logger.transports.Loggly, {
     token: process.env.LOGGLY_TOKEN,
     subdomain: process.env.LOGGLY_SUBDOMAIN,
     tags: ["Winston-NodeJS"],
@@ -19,7 +19,7 @@ if ( process.env.LOGGLY_TOKEN ){
 
 process.on('uncaughtException', function(err) {
   logger.error("Unexpected error: "+err)
-  logger.log("Stack trace dumped to console");
+  logger.log('error',"Stack trace dumped to console");
   console.trace(err);
   process.exit(1);
 })


### PR DESCRIPTION
issue #13.

Still uses the `PGO_LOCATION` environment variable - but can take a form `51.42,-0.10`
